### PR TITLE
Update setup.sh to point to current release

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,7 @@ mkdir data
 cd data
 
 function dl_it() {
-    wget https://github.com/MadryLab/robust-features-code/releases/download/v0.1/$1
+    wget https://github.com/MadryLab/robust-features-code/releases/download/v0.2/$1
     unzip $1
 }
 


### PR DESCRIPTION
This hardcodes the current release version. 

Edit: ~I'll separately submit a PR that automatically points to the latest release, so you can decide which approach fits your workflow better. :-)~ Maybe it's because the latest release is a "Pre-release", but I could only get this to work atm.